### PR TITLE
Unified order of arguments

### DIFF
--- a/README.org
+++ b/README.org
@@ -353,6 +353,20 @@ Available in the [[https://github.com/AccelerationNet/access/][Access]] library:
 Available in the [[https://github.com/vseloved/rutils/blob/master/docs/tutorial.md][Rutils]] library: dot notation and index-based
 access. =(elt (nth 1 (foo-slot2 (bar-slot1 obj)) 0)= can be written =@obj.slot1.slot2#1#0=.
 
+*** Unified order of arguments
+**** Details
+In the case of functions, macros, perhaps even some conditions, the order of aguments is generally speaking unclear. When a given operation takes a data structure and an index/key to read from the data structure - in some cases the key is the 1st argument and in some cases it's the 2nd argument.
+
+**** Reasoning
+This issue is an unnecessary burden on one's mind when developing a project and forces the developer to break their focus to think about an out of place implementation detail instead of on the program's business logic. It's just is something that is there for no reason whatsoever other than legacy reasons.
+
+**** Current status
+The standard contains functions like (gethash key hashtable) and (aref array index).
+In the case of gethash the data structure (hashtable) is the 2nd argument.
+In the case of aref the data structure (array) is the 1st argument.
+These are just 2 examples of such inconsistency.
+One potential example to follow would be the bulk of list operations, like mapcar, which take key (lambda) as the 1st argument and list(s) (data structure) as the 2nd or 3rd (etc) arguments and those kinds of functions are pretty much consistent across the board.
+
 -----------
 ** System definitions
 *** Packages

--- a/README.org
+++ b/README.org
@@ -355,10 +355,10 @@ access. =(elt (nth 1 (foo-slot2 (bar-slot1 obj)) 0)= can be written =@obj.slot1.
 
 *** Unified order of arguments
 **** Details
-In the case of functions, macros, perhaps even some conditions, the order of aguments is generally speaking unclear. When a given operation takes a data structure and an index/key to read from the data structure - in some cases the key is the 1st argument and in some cases it's the 2nd argument.
+Operations (functions, macros etc) have predictable (possibly identical) order of arguments. If an operations takes for example 2 arguments (data structure and an index/key) - it is expected that the data structure is always on the same position and the key is also on the same position across the board, regardless of what the actual positions are.
 
 **** Reasoning
-This issue is an unnecessary burden on one's mind when developing a project and forces the developer to break their focus to think about an out of place implementation detail instead of on the program's business logic. It's just is something that is there for no reason whatsoever other than legacy reasons.
+This issue is an unnecessary burden on one's mind when developing a project and forces the developer to break their focus to think about an out of place implementation detail instead of on the program's business logic. It's just is something that is there for no reason other than legacy.
 
 **** Current status
 The standard contains functions like (gethash key hashtable) and (aref array index).


### PR DESCRIPTION
This PR adds mention of the order of arguments in different functions. I give 2 examples in the commits for gethash and aref which are incompatible with each other as far as the order is concerned.